### PR TITLE
fix: Replace `time` with `relative-time` to make "Last Updated" output work again

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -166,7 +166,7 @@ function makeLabel(text, octicon) {
 }
 
 function makeUpdateLabel(time) {
-  return `<time datetime="${time}" is="relative-time"></time>`;
+  return `<relative-time datetime="${time}"></relative-time>`;
 }
 
 function issueOrPrLink(type, repoPath, contributor) {


### PR DESCRIPTION
This replaced a broken usage of `time` with a working `relative-time` so that the addon/extension can display the "Last Updated" time properly again.

closes #31