### PR TITLE
feat: Firefox Support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
   },
   "permissions": [
     "https://github.com/*/*",
+    "https://api.github.com/*",
     "storage",
     "identity"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,5 +41,10 @@
   "options_ui": {
     "page": "options.html",
     "chrome_style": true
+  },
+  "applications": {
+    "gecko": {
+      "id": "contributors-on-github@hzoo.github.com"
+    }
   }
 }


### PR DESCRIPTION
This makes a few tiny changes which makes this extension compatible to Firefox and will enable it to be uploaded to the Firefox Addon Store at https://addons.mozilla.org/ via https://addons.mozilla.org/en-US/developers/

- Fixes broken storage access by setting an addon ID, as required. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#Firefox_(Gecko)_propertiesfor for more information.
- Fixes the non-working `fetch` calls by adding `api.github.com` to the `permissions` array in `manifest.json` which is needed in Firefox to be able to request URLs.

When this PR is merged, you should be able to just zip the content of `/src` and upload the resulting file as an addon via https://addons.mozilla.org/en-US/developers/

closes #27