### PR TITLE
move auth to headers

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -54,7 +54,6 @@ function buildUrl({
   sort,
   order,
   per_page,
-  access_token,
 }) {
   let query = `${base}?q=`;
   query += `${author ? `+author:${author}` : ""}`;
@@ -90,7 +89,6 @@ function contributorCount({
   }
 
   let searchURL = buildUrl({
-    access_token,
     base: "https://api.github.com/search/issues",
     order: "asc",
     per_page: "1",
@@ -103,7 +101,11 @@ function contributorCount({
     sort: "created",
   });
 
-  return fetch(searchURL)
+  return fetch(searchURL, {
+    headers: {
+      Authorization: `token ${access_token}`,
+    },
+  })
     .then((res) => res.json())
     .then(function (json) {
       if (json.errors || json.message) {


### PR DESCRIPTION
Got an email that linked to https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

![image](https://user-images.githubusercontent.com/588473/108609917-5bad2400-739f-11eb-9e9b-eb26b067e78e.png)
