### PR TITLE
Fix Firefox version badge in readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ env:
 
 # FILE GENERATED WITH: npx ghat fregante/ghatemplates/webext
 # SOURCE: https://github.com/fregante/ghatemplates
+# OPTIONS: {"set":["on.schedule=[{\"cron\": \"41 12 1 * *\"}]"]}
 
 name: Release
 on:
@@ -25,7 +26,7 @@ jobs:
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version
-      - uses: notlmn/release-with-changelog@v3
+      - uses: fregante/release-with-changelog@v3
         if: steps.daily-version.outputs.created
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Much thanks to @Pocket-titan and @djrosenbaum for working on the logo 🖼!
 
 [<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_128x128.png" width="48" alt="Chrome" valign="middle">][link-chrome] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/cjbacdldhllelehomkmlniifaojgaeph.svg?label=%20">][link-chrome] also compatible with [<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_48x48.png" width="24" alt="Edge" valign="middle">][link-chrome] [<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/opera/opera_48x48.png" width="24" alt="Opera" valign="middle">][link-chrome]
 
-[<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_128x128.png" width="48" alt="Firefox" valign="middle">][link-firefox] [<img valign="middle" src="https://img.shields.io/amo/v/refined-github-.svg?label=%20">][link-firefox]
+[<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_128x128.png" width="48" alt="Firefox" valign="middle">][link-firefox] [<img valign="middle" src="https://img.shields.io/amo/v/contributor-on-github.svg?label=%20">][link-firefox]
 
 ---
 


### PR DESCRIPTION
It still pointed to Refined GitHub.

Also I inlined the custom cron option. The correct call should have been:

```
npx ghat fregante/ghatemplates/webext --set 'on.schedule=[{"cron": "41 12 1 * *"}]'
```

So that future updates won't override it when you call

```
npx ghat
```

